### PR TITLE
fix: copy-paste error? use from_pip for pip

### DIFF
--- a/src/pamba/cli.py
+++ b/src/pamba/cli.py
@@ -167,7 +167,7 @@ def install(args: Namespace, conda_args: Optional[List[str]] = None) -> None:
                 print(f"  - {req}")
         if from_pip:
             print("Would install from pip:")
-            for req in from_conda:
+            for req in from_pip:
                 print(f"  - {req}")
     else:
         if from_conda:


### PR DESCRIPTION
Minor fix, while trying to debug #3 
install with `--dry-run` wasn't properly reporting `pip` installs.
