### PR TITLE
fix: use subprocess.run instead of check_call()

### DIFF
--- a/src/pamba/cli.py
+++ b/src/pamba/cli.py
@@ -8,7 +8,7 @@ import sys
 from argparse import ArgumentParser, Namespace
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from subprocess import check_call
+from subprocess import run
 from typing import List, Optional, Sequence, Tuple, Union
 from urllib import error, request
 
@@ -135,13 +135,13 @@ def conda_install(requires: List[str], extra_args: Optional[List[str]] = None) -
         binary = "conda"
     else:
         raise RuntimeError("Neither conda nor mamba available on PATH")
-    check_call([binary, "install"] + extra_args + requires)
+    run([binary, "install"] + extra_args + requires)
 
 
 def pip_install(requires: List[str], extra_args: Optional[List[str]] = None) -> None:
     if extra_args is None:
         extra_args = []
-    check_call(["pip", "install"] + extra_args + requires)
+    run(["pip", "install"] + extra_args + requires)
 
 
 def install(args: Namespace, conda_args: Optional[List[str]] = None) -> None:


### PR DESCRIPTION
Fixes https://github.com/tlambert03/pamba/issues/3
I can't say i totally understand why.
The docs suggest using `run()` is the way to go:
https://docs.python.org/3/library/subprocess.html#using-the-subprocess-module
`The recommended approach to invoking subprocesses is to use the [run()](https://docs.python.org/3/library/subprocess.html#subprocess.run) function for all use cases it can handle.`
And it works. If you add `check=True` which should be similar to `check_call` you get the same issue as before. So it is somehow related to the exit code, but 🤷‍♂️ 
Still, this is an awesome tool, so ❤️ hope this helps.