### PR TITLE
feat: if dry-run, pass the flag to conda for more info

### DIFF
--- a/src/pamba/cli.py
+++ b/src/pamba/cli.py
@@ -165,6 +165,9 @@ def install(args: Namespace, conda_args: Optional[List[str]] = None) -> None:
             print("Would install from conda:")
             for req in from_conda:
                 print(f"  - {req}")
+            print("conda dry-run output:")
+            conda_args.extend(["--dry-run", "--no-banner"])
+            conda_install(from_conda, extra_args=conda_args)
         if from_pip:
             print("Would install from pip:")
             for req in from_pip:

--- a/src/pamba/cli.py
+++ b/src/pamba/cli.py
@@ -172,6 +172,7 @@ def install(args: Namespace, conda_args: Optional[List[str]] = None) -> None:
             print("Would install from pip:")
             for req in from_pip:
                 print(f"  - {req}")
+            print("pip dry-run output:")
             pip_install([r.replace(" ", "") for r in from_pip], ["--dry-run"])
     else:
         if from_conda:

--- a/src/pamba/cli.py
+++ b/src/pamba/cli.py
@@ -172,6 +172,7 @@ def install(args: Namespace, conda_args: Optional[List[str]] = None) -> None:
             print("Would install from pip:")
             for req in from_pip:
                 print(f"  - {req}")
+            pip_install([r.replace(" ", "") for r in from_pip], ["--dry-run"])
     else:
         if from_conda:
             print("installing conda deps")

--- a/src/pamba/cli.py
+++ b/src/pamba/cli.py
@@ -166,6 +166,7 @@ def install(args: Namespace, conda_args: Optional[List[str]] = None) -> None:
             for req in from_conda:
                 print(f"  - {req}")
             print("conda dry-run output:")
+            conda_args = conda_args or []
             conda_args.extend(["--dry-run", "--no-banner"])
             conda_install(from_conda, extra_args=conda_args)
         if from_pip:


### PR DESCRIPTION
This PR passes the `--dry-run` flag to conda/mamba & pip to provide more info about the the packages being installed by the solvers.
This is quite helpful when troubleshooting.

Here's example output for `napari-aicsimageio` repo in an env with napari on macOS arm64.
```
Would install from conda:
  - aicsimageio >=4.6.3
  - fsspec >=2022.7.1
  - napari >=0.4.11
  - psutil >=5.7.0
  - readlif >=0.6.4
conda dry-run output:

Looking for: ["aicsimageio[version='>=4.6.3']", "fsspec[version='>=2022.7.1']", "napari[version='>=0.4.11']", "psutil[version='>=5.7.0']", "readlif[version='>=0.6.4']"]

conda-forge/osx-arm64                                       Using cache
conda-forge/noarch                                          Using cache

Pinned packages:
  - python 3.10.*


Transaction

  Prefix: /Users/piotrsobolewski/Dev/miniforge3/envs/napari-dev

  Updating specs:

   - aicsimageio[version='>=4.6.3']
   - fsspec[version='>=2022.7.1']
   - napari[version='>=0.4.11']
   - psutil[version='>=5.7.0']
   - readlif[version='>=0.6.4']
   - ca-certificates
   - certifi
   - openssl


  Package                          Version  Build              Channel                     Size
─────────────────────────────────────────────────────────────────────────────────────────────────
  Install:
─────────────────────────────────────────────────────────────────────────────────────────────────

  + aicsimageio                      4.9.4  pyhd8ed1ab_0       conda-forge/noarch        Cached
  + elementpath                      2.5.3  pyhd8ed1ab_0       conda-forge/noarch        Cached
  + ffmpeg                           5.1.2  gpl_hf318d42_105   conda-forge/osx-arm64     Cached
  + gmp                              6.2.1  h9f76cd9_0         conda-forge/osx-arm64     Cached
  + gnutls                           3.7.8  h9f1a10d_0         conda-forge/osx-arm64     Cached
  + imageio-ffmpeg                   0.4.7  pyhd8ed1ab_0       conda-forge/noarch        Cached
  + lame                             3.100  h1a8c8d9_1003      conda-forge/osx-arm64     Cached
  + libidn2                          2.3.4  h1a8c8d9_0         conda-forge/osx-arm64     Cached
  + libtasn1                        4.19.0  h1a8c8d9_0         conda-forge/osx-arm64     Cached
  + libunistring                    0.9.10  h3422bc3_0         conda-forge/osx-arm64     Cached
  + libvpx                          1.11.0  hc470f4d_3         conda-forge/osx-arm64     Cached
  + napari                          0.4.17  pyh275ddea_0_pyqt  conda-forge/noarch        Cached
  + nettle                           3.8.1  h63371fa_1         conda-forge/osx-arm64     Cached
  + ome-types                        0.3.2  pyhd8ed1ab_0       conda-forge/noarch        Cached
  + openh264                         2.3.1  hb7217d7_1         conda-forge/osx-arm64     Cached
  + p11-kit                         0.24.1  h29577a5_0         conda-forge/osx-arm64     Cached
  + readlif                          0.6.5  pyhd8ed1ab_0       conda-forge/noarch          30kB
  + resource_backed_dask_array       0.1.0  pyhd8ed1ab_1       conda-forge/noarch        Cached
  + svt-av1                          1.4.1  h7ea286d_0         conda-forge/osx-arm64     Cached
  + x264                        1!164.3095  h57fd34a_2         conda-forge/osx-arm64     Cached
  + x265                               3.5  hbc6ce65_3         conda-forge/osx-arm64     Cached
  + xmlschema                       1.11.3  pyhd8ed1ab_0       conda-forge/noarch        Cached

  Downgrade:
─────────────────────────────────────────────────────────────────────────────────────────────────

  - vispy                           0.12.1  py310hb614ae6_0    conda-forge                     
  + vispy                           0.11.0  py310hb614ae6_1    conda-forge/osx-arm64     Cached

  Summary:

  Install: 22 packages
  Downgrade: 1 packages

  Total download: 30kB

─────────────────────────────────────────────────────────────────────────────────────────────────


Dry run. Exiting.

DryRunExit: Dry run. Exiting.

Would install from pip:
  - aicspylibczi >=3.0.5
  - bioformats-jar
Collecting aicspylibczi>=3.0.5
  Using cached aicspylibczi-3.0.5-cp310-cp310-macosx_11_0_arm64.whl (657 kB)
Collecting bioformats-jar
  Using cached bioformats_jar-2020.5.27-py3-none-any.whl (10 kB)
Requirement already satisfied: numpy>=1.14.1 in /Users/piotrsobolewski/Dev/miniforge3/envs/napari-dev/lib/python3.10/site-packages (from aicspylibczi>=3.0.5) (1.23.5)
Collecting scyjava
  Using cached scyjava-1.8.1-py3-none-any.whl (24 kB)
Collecting jpype1>=1.3.0
  Using cached JPype1-1.4.1-cp310-cp310-macosx_10_9_universal2.whl (590 kB)
Collecting jgo
  Using cached jgo-1.0.5-py3-none-any.whl (15 kB)
Requirement already satisfied: packaging in /Users/piotrsobolewski/Dev/miniforge3/envs/napari-dev/lib/python3.10/site-packages (from jpype1>=1.3.0->scyjava->bioformats-jar) (22.0)
Requirement already satisfied: psutil in /Users/piotrsobolewski/Dev/miniforge3/envs/napari-dev/lib/python3.10/site-packages (from jgo->scyjava->bioformats-jar) (5.9.4)
Would install JPype1-1.4.1 aicspylibczi-3.0.5 bioformats-jar-2020.5.27 jgo-1.0.5 scyjava-1.8.1
```

