### PR TITLE
fix: update tox.ini passenv for tox 4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,11 @@ platform =
     macos: darwin
     linux: linux
     windows: win32
-passenv = CI GITHUB_ACTIONS DISPLAY XAUTHORITY
+passenv = 
+    CI
+    GITHUB_ACTIONS
+    DISPLAY
+    XAUTHORITY
 setenv =
     PYTHONPATH = {toxinidir}
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ platform =
     macos: darwin
     linux: linux
     windows: win32
-passenv = 
+passenv =
     CI
     GITHUB_ACTIONS
     DISPLAY


### PR DESCRIPTION
Attempt to fix the error returned by tox in tests.
Other option is to use commas, see
https://tox.wiki/en/latest/upgrading.html#changed-ini-rules

commas are tox 4 only, line breaks appear safe for tox 3 and 4, hence the choice.